### PR TITLE
Fix deprecated role and update plugin description

### DIFF
--- a/lib/main.cjsx
+++ b/lib/main.cjsx
@@ -8,7 +8,7 @@ module.exports =
   #
   activate: (@state) ->
     ComponentRegistry.register SendToOmnifocus,
-      role: 'message:Toolbar'
+      role: 'ThreadActionsToolbarButton'
 
   # Serialize is called when your package is about to be unmounted.
   # You can return a state object that will be passed back to your package

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "nylas": ">=0.4.10-4e3595b"
   },
-  "description": "Enter a description of your package!",
+  "description": "Send email to Omnifocus",
   "dependencies": {},
   "license": "MIT"
 }


### PR DESCRIPTION
Hi @hodak 👋 

Great plugin. Thanks for creating it. Please could you consider accepting the following small changes:

1) Changed `role: 'message:Toolbar'` to `role: 'ThreadActionsToolbarButton'` to address the following deprecation warning:

![image](https://cloud.githubusercontent.com/assets/1283509/15288996/02fd7b6a-1b67-11e6-8bcf-f08259893ffc.png)

2) Updated `package.json` with a short plugin description:

![image](https://cloud.githubusercontent.com/assets/1283509/15289047/5b3942f0-1b67-11e6-8a3d-89e8a5f74012.png)

The changes can be viewed [here](https://github.com/hodak/nylas-send-to-omnifocus/pull/7/files).
